### PR TITLE
Dark art‑deco rays theme: default to dark mode and restyle UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#FFFFFF" />
+    <meta name="theme-color" content="#05051f" />
     <meta
       name="description"
       content="Fermi Poker - A game of numerical estimation and strategic betting"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -20,6 +20,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#D4A244",
-  "background_color": "#FBFAF4"
+  "theme_color": "#05051f",
+  "background_color": "#05051f"
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,28 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate, Link, useLocation } from 'react-router-dom';
 import FermiPokerIntro from './components/FermiPokerIntro';
 import CategorySelection from './components/CategorySelection';
 import FermiPokerGame from './components/FermiPokerGame';
+import FermiPokerRules from './components/FermiPokerRules';
 import ScrollToTop from './components/ScrollToTop';
 import { createQuestionSets } from './data/questionSets';
 import './styles.css';
 
-const App = () => {
+const countQuestions = (items) => Object.values(items).reduce((total, item) => {
+  const ownQuestions = item.questions ? item.questions.length : 0;
+  const nestedQuestions = item.subcategories ? countQuestions(item.subcategories) : 0;
+
+  return total + ownQuestions + nestedQuestions;
+}, 0);
+
+const AppContent = () => {
   const questionSets = createQuestionSets();
+  const questionCount = countQuestions(questionSets);
+  const location = useLocation();
+  const isLandingPage = location.pathname === '/';
   const [darkMode, setDarkMode] = useState(true);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  
+
   // Refs for handling clicks outside the settings menu
   const settingsMenuRef = useRef(null);
   const settingsButtonRef = useRef(null);
@@ -20,15 +31,15 @@ const App = () => {
   useEffect(() => {
     function handleClickOutside(event) {
       if (
-        settingsMenuRef.current && 
+        settingsMenuRef.current &&
         !settingsMenuRef.current.contains(event.target) &&
-        settingsButtonRef.current && 
+        settingsButtonRef.current &&
         !settingsButtonRef.current.contains(event.target)
       ) {
         setSettingsOpen(false);
       }
     }
-    
+
     document.addEventListener('mousedown', handleClickOutside);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
@@ -43,134 +54,135 @@ const App = () => {
     const themeColorMeta = document.querySelector('meta[name="theme-color"]');
     if (themeColorMeta) {
       themeColorMeta.setAttribute(
-        'content', 
+        'content',
         newDarkMode ? '#05051f' : '#100d29'  // darker art-deco palette
       );
     }
   };
 
   return (
-    <Router>
+    <>
       {/* This ScrollToTop component will scroll to top when route changes */}
       <ScrollToTop />
-      
-      <div className={`min-h-screen font-primary geometric-background ${darkMode ? 'dark' : 'light'}`}>
-        
-        <div className="relative z-10 max-w-4xl mx-auto pb-2 pt-1 px-3 sm:px-4">
+
+      <div className={`min-h-screen font-primary geometric-background ${isLandingPage ? 'landing-mode' : ''} ${darkMode ? 'dark' : 'light'}`}>
+        <div className={`app-content relative z-10 ${isLandingPage ? 'landing-content' : 'max-w-4xl'} mx-auto pb-2 pt-1 px-3 sm:px-4`}>
           {/* Settings button and dropdown */}
-          <div className="absolute top-4 right-4 z-20 relative">
-            <button 
-              ref={settingsButtonRef}
-              onClick={() => setSettingsOpen(!settingsOpen)} 
-              className="settings-toggle"
-              aria-label="Settings"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-                <path d="M4 5h12M6 10h10M4 15h12" />
-              </svg>
-            </button>
-            
-            {/* Settings dropdown menu */}
-            {settingsOpen && (
-              <div 
-                ref={settingsMenuRef}
-                className="settings-menu absolute right-0 top-full mt-2 rounded-lg shadow-xl z-50"
+          {!isLandingPage && (
+            <div className="absolute top-4 right-4 z-20 relative">
+              <button
+                ref={settingsButtonRef}
+                onClick={() => setSettingsOpen(!settingsOpen)}
+                className="settings-toggle"
+                aria-label="Settings"
               >
-                <div className="settings-menu-content p-3">
-                  {/* Theme toggle option */}
-                  <div className="flex justify-between items-center py-2">
-                    <span>Theme</span>
-                    <button 
-                      onClick={(e) => {
-                        e.stopPropagation(); // Prevent menu from closing
-                        toggleDarkMode();
-                      }}
-                      className="settings-theme-toggle px-3 py-1 rounded-lg text-sm font-medium border transition-all"
-                    >
-                      {darkMode ? (
-                        <span className="flex items-center">
-                          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1.5" viewBox="0 0 20 20" fill="currentColor">
-                            <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
-                          </svg>
-                          Dark
-                        </span>
-                      ) : (
-                        <span className="flex items-center">
-                          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1.5" viewBox="0 0 20 20" fill="currentColor">
-                            <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
-                          </svg>
-                          Light
-                        </span>
-                      )}
-                    </button>
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                  <path d="M4 5h12M6 10h10M4 15h12" />
+                </svg>
+              </button>
+
+              {/* Settings dropdown menu */}
+              {settingsOpen && (
+                <div
+                  ref={settingsMenuRef}
+                  className="settings-menu absolute right-0 top-full mt-2 rounded-lg shadow-xl z-50"
+                >
+                  <div className="settings-menu-content p-3">
+                    {/* Theme toggle option */}
+                    <div className="flex justify-between items-center py-2">
+                      <span>Theme</span>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation(); // Prevent menu from closing
+                          toggleDarkMode();
+                        }}
+                        className="settings-theme-toggle px-3 py-1 rounded-lg text-sm font-medium border transition-all"
+                      >
+                        {darkMode ? (
+                          <span className="flex items-center">
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1.5" viewBox="0 0 20 20" fill="currentColor">
+                              <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+                            </svg>
+                            Dark
+                          </span>
+                        ) : (
+                          <span className="flex items-center">
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1.5" viewBox="0 0 20 20" fill="currentColor">
+                              <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
+                            </svg>
+                            Light
+                          </span>
+                        )}
+                      </button>
+                    </div>
                   </div>
-                  
-                  {/* Future settings can be added here */}
-                  {/* Example: Language selection
-                  <div className="flex justify-between items-center py-2 border-t mt-1">
-                    <span>Language</span>
-                    <button className="settings-theme-toggle px-3 py-1 rounded-lg text-sm font-medium border transition-all">
-                      <span className="flex items-center">English</span>
-                    </button>
-                  </div>
-                  */}
                 </div>
-              </div>
-            )}
-          </div>
-        
-          {/* Header with Link for navigation */}
-          <header className="text-center pt-28 pb-3 mb-4">
-            <Link 
-              to="/"
-              className="text-3xl sm:text-4xl font-display font-medium mb-1 cursor-pointer hover:text-golden-accent transition-colors"
-            >
-              Fermi Poker
-            </Link>
-            <div className="flex justify-center">
-              <div className="w-24 h-1 bg-golden-accent rounded-full"></div>
+              )}
             </div>
-          </header>
-          
+          )}
+
+          {/* Header with Link for navigation */}
+          {!isLandingPage && (
+            <header className="text-center pt-28 pb-3 mb-4">
+              <Link
+                to="/"
+                className="text-3xl sm:text-4xl font-display font-medium mb-1 cursor-pointer hover:text-golden-accent transition-colors"
+              >
+                Fermi Poker
+              </Link>
+              <div className="flex justify-center">
+                <div className="w-24 h-1 bg-golden-accent rounded-full"></div>
+              </div>
+            </header>
+          )}
+
           {/* Main content area */}
-          <div className="main-bg rounded-xl p-4 sm:p-5 relative overflow-hidden">
-            
+          <div className={`${isLandingPage ? 'landing-main' : 'main-bg rounded-xl p-4 sm:p-5'} relative overflow-hidden`}>
             <Routes>
-              <Route 
-                path="/" 
-                element={<FermiPokerIntro />} 
+              <Route
+                path="/"
+                element={<FermiPokerIntro questionCount={questionCount} />}
               />
-              <Route 
-                path="/categories" 
+              <Route
+                path="/rules"
+                element={<FermiPokerRules />}
+              />
+              <Route
+                path="/categories"
                 element={
-                  <CategorySelection 
-                    questionSets={questionSets} 
+                  <CategorySelection
+                    questionSets={questionSets}
                   />
-                } 
+                }
               />
-              <Route 
-                path="/play/*" 
+              <Route
+                path="/play/*"
                 element={
-                  <FermiPokerGame 
-                    questionSets={questionSets} 
-                    darkMode={darkMode} 
+                  <FermiPokerGame
+                    questionSets={questionSets}
+                    darkMode={darkMode}
                   />
-                } 
+                }
               />
-              <Route 
-                path="*" 
-                element={<Navigate to="/" replace />} 
+              <Route
+                path="*"
+                element={<Navigate to="/" replace />}
               />
             </Routes>
           </div>
-          
         </div>
-        
+
         {/* Import Google Fonts */}
         <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;600;700&family=Newsreader:wght@400;500;600&display=swap" rel="stylesheet" />
       </div>
-    </Router>
+    </>
   );
 };
+
+const App = () => (
+  <Router>
+    <AppContent />
+  </Router>
+);
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import './styles.css';
 
 const App = () => {
   const questionSets = createQuestionSets();
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(true);
   const [settingsOpen, setSettingsOpen] = useState(false);
   
   // Refs for handling clicks outside the settings menu
@@ -44,7 +44,7 @@ const App = () => {
     if (themeColorMeta) {
       themeColorMeta.setAttribute(
         'content', 
-        newDarkMode ? '#1F1A15' : '#FBFAF4'  // dark-bg or cream-tan
+        newDarkMode ? '#05051f' : '#100d29'  // darker art-deco palette
       );
     }
   };

--- a/src/components/FermiPokerIntro.js
+++ b/src/components/FermiPokerIntro.js
@@ -1,205 +1,70 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
-const FermiPokerIntro = () => {
+const FermiPokerIntro = ({ questionCount = 0 }) => {
   const navigate = useNavigate();
 
-  const goToCategories = () => {
-    navigate('/categories');
-  };
-
-  // Example gameplay steps
-  const gameplaySteps = [
-    {
-      number: "1",
-      title: "Question reveal",
-      content: "Before seeing the question, each player must put one or more chips into the pot. Then the question is revealed, for example: \"How many chickens are killed every year for meat?\" The size of this mandatory bet should increase every other question."
-    },
-    {
-      number: "2",
-      title: "Secret guesses",
-      content: "Each player secretly writes down their guess as a range (e.g. 20 billion to 100 billion). Alternatively, you can also require everyone to play with exact numbers instead of ranges."
-    },
-    {
-      number: "3",
-      title: "Betting round #1",
-      content: "Betting moves clockwise, starting with a different player each question. On your turn, you may *check* (pass without betting, if no one has bet yet), *raise* (bet more than the current highest bet), *call* (match it), or *fold* (drop out and forfeit the pot). Betting continues until all players have either folded or matched the highest bet."
-    },
-    {
-      number: "4",
-      title: "Hint #1 (+ Betting round #2)",
-      content: "When the first betting round is over, the first hint is revealed. The hint helps all players to estimate how good the initial guess is. As in the first betting round, players can now perform various actions."
-    },
-    {
-      number: "5",
-      title: "Hint #2 (+ Betting round #3)",
-      content: "After the second betting round is over, a second hint is revealed and the third betting round is played."
-    },
-    {
-      number: "6",
-      title: "Answer reveal",
-      content: "Before the fourth and final betting round, the answer to the guessing question is revealed so that all players know if they are close to the answer."
-    },
-    {
-      number: "7",
-      title: "Betting round #4",
-      content: "After the answer reveal, there is a fourth and final betting round. After the answer reveal, there is a fourth and final betting round."
-    },
-    {
-      number: "8",
-      title: "Showdown",
-      content: "When the final betting round ends with two or more players still in, everyone left reveals their guess. Folded players—and anyone who won before it came to the showdown—don't have to reveal their guess. The pot goes to the player with the narrowest range that contains the correct answer; if several ranges are equally narrow, those players split the pot. If no player has the correct answer inside their range, whoever's median of their range is closest to the answer wins."
-    }
-  ];
-
   return (
-    <div className="intro-section p-1 mb-20">
-      {/* What is Fermi Poker section */}
-      <div className="mb-6">
-        <h2 className="text-header-small sm:text-header font-display font-medium pb-2.5 border-b border-golden-accent mt-0 mb-3">What is Fermi Poker?</h2>
-        <p className="leading-normal">
-          Fermi Poker is like poker, but instead of cards, players make guesses about questions that seem unknowable at first — like "How many humans have ever lived?"
+    <main className="quiz-poker-home" aria-label="Fermi Poker home">
+      <div className="quiz-poker-frame" aria-hidden="true">
+        <span className="frame-corner frame-corner-top-left" />
+        <span className="frame-corner frame-corner-top-right" />
+        <span className="frame-corner frame-corner-bottom-left" />
+        <span className="frame-corner frame-corner-bottom-right" />
+        <span className="frame-knot frame-knot-top-left" />
+        <span className="frame-knot frame-knot-top-right" />
+        <span className="frame-knot frame-knot-left-top" />
+        <span className="frame-knot frame-knot-left-bottom" />
+        <span className="frame-knot frame-knot-right-top" />
+        <span className="frame-knot frame-knot-right-bottom" />
+        <span className="frame-knot frame-knot-bottom-left" />
+        <span className="frame-knot frame-knot-bottom-right" />
+      </div>
+
+      <div className="home-flag" aria-hidden="true">
+        <span className="flag-red" />
+        <span className="flag-white" />
+        <span className="flag-blue" />
+      </div>
+
+      <button
+        type="button"
+        className="home-info-button"
+        onClick={() => navigate('/rules')}
+        aria-label="Open rules and description"
+      >
+        i
+      </button>
+
+      <section className="quiz-poker-hero">
+        <h1 className="quiz-poker-title">
+          <span>Fermi</span>
+          <span>Poker</span>
+        </h1>
+      </section>
+
+      <section className="quiz-poker-actions" aria-label="Start and rules">
+        <p className="question-count">
+          {questionCount.toLocaleString()} questions available
         </p>
-        <p className="leading-normal">
-          Players write down secret guesses, bet on their answers, get helpful hints, bet again, and the closest guess wins.
-        </p>
-      </div>
-      
-      {/* What Do You Need section */}
-      <div className="highlight-section p-4 rounded-xl mb-6">
-        <h3 className="font-medium mt-0 mb-3">What Do You Need?</h3>
-        <ul className="list-disc pl-5 m-0 space-y-3 leading-normal">
-          <li>At least one other person physically present to play with you, but it's more fun with larger groups</li>
-          <li>Something to write down guesses, and poker chips or other play money</li>
-        </ul>
-      </div>
-      
-      {/* Example Gameplay section */}
-      <div className="mb-6">
-        <h3 className="text-xl font-display font-medium pb-2.5 border-b mb-6">How to Play</h3>
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-5">
-          {gameplaySteps.map((step, index) => (
-            <div key={index} className="gameplay-steps">
-              <div className="gameplay-step-row">
-                <div className="step-number-circle">{step.number}</div>
-                <div className="step-content">
-                  <h4>{step.title}</h4>
-                  <p className="leading-normal">{step.content}</p>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-      
-      {/* Rules section */}
-      <div className="mb-6 leading-normal">
-        <h3 className="text-xl font-display font-medium pb-2.5 border-b mb-6">Rules</h3>
-        <p className="mb-3">
-          If you are familiar with No Limit Texas Hold'Em Poker, you'll find that the rules are very similar, 
-          however we have made some adjustment to maximize the educational potential and to accommodate the fact that we don't have cards:
-        </p>
-        <ul className="list-disc pl-5 space-y-2">
-          <li>If you were the last to raise in a betting round, you can't raise again.</li>
-          <li>If everyone has folded, the remaining player doesn't have to show his answer.</li>
-          <li>A player can fold at any time, which means he gives up all the chips he has already put into the pot, including the mandatory ante, but he doesn't have to show his answer.</li>
-          <li>Each round, players have to pay a mandatory minimum ante. If one has less chips than the mandatory ante, one automatically goes all-in.</li>
-          <li>A player going all-in, can not win from another player more than he went all-in with. If other players continue playing with more chips, a side-pot is created that only the people can win that have contributed to it.</li>
-        </ul>
-      </div>
-      
-      {/* Meta-Game Option section */}
-      <div className="highlight-section p-4 rounded-xl mb-6">
-        <h3 className="font-medium mt-0 mb-3">Meta-Game Option</h3>
-        <ul className="list-disc pl-5 m-0 space-y-3 leading-normal">
-          <li>When playing in large groups, which might have very different skill levels, it might make sense to add another layer to the game so that it is more fun for everyone even if you have folded and are just watching.</li>
-          <li>In games with meta-game enabled, players can predict who will win each question. With 3 correct predictions, bankrupt players can rejoin the game with a small stack.</li>
-          <li>Players can't bet on themselves</li>
-        </ul>
-      </div>
-      
-      {/* Example Worked Through section */}
-      <div className="mb-6 leading-normal">
-          <h3 className="text-xl font-display font-medium pb-2.5 border-b mb-6">An Example Worked Far Too In-Depth</h3>
-          <p className="mb-3">
-            It's hard to explain how to solve a Fermi Question, so let me show you one and walk you through it. Here's a classic, hoping that the pandemic didn't change the answer.
-          </p>
-          <p className="mb-3 font-bold italic">How many piano tuners are there in Chicago?</p>
-          <p className="mb-3">
-            To begin, we need the population of Chicago. The population turns out to be around 2.5 million, but keeping Remark 2.2 in mind, the metropolitan area is a bit higher, about 10 million. We'll go in between at about 5 million.
-          </p>
-          <p className="mb-3">
-            We'll first consider how many pianos there are in Chicago, and by extension, the demand of piano tuners for those pianos. The average household size in the US is about 2; there are many people who are single, some live with a partner, and some (fewer) have children as well. Let's then say that about 1 in 10 households own a piano that needs to be tuned yearly. This gives us about:
-          </p>
-          <div className="p-4 bg-gray-50 dark:bg-dark-soft rounded-lg mb-3">
-            5,000,000 people ÷ 2 people per household × 0.1 pianos per household = 250,000 pianos
-          </div>
-          <p className="mb-3">
-            Let's also consider that some business establishments have pianos: schools, churches, concert venues, recording studios, and so on. These are fewer in number than households, but more likely to have pianos. Let's say there are about 10,000 such establishments with pianos in Chicago.
-          </p>
-          <div className="p-4 bg-gray-50 dark:bg-dark-soft rounded-lg mb-3">
-            250,000 + 10,000 = 260,000 pianos in Chicago
-          </div>
-          <p className="mb-3">
-            Now, if a piano needs to be tuned once per year on average, and a tuner can tune, say, 5 pianos per day, working 5 days a week for 50 weeks a year, each tuner can service:
-          </p>
-          <div className="p-4 bg-gray-50 dark:bg-dark-soft rounded-lg mb-3">
-            5 pianos/day × 5 days/week × 50 weeks/year = 1,250 pianos per year per tuner
-          </div>
-          <p className="mb-3">
-            So the number of piano tuners needed in Chicago would be:
-          </p>
-          <div className="p-4 bg-gray-50 dark:bg-dark-soft rounded-lg mb-3">
-            260,000 pianos ÷ 1,250 pianos per tuner = 208 piano tuners
-          </div>
-          <p>
-            Rounding a bit, we'd estimate there are about 200 piano tuners in Chicago. The actual number is around 40-50, which is in the same order of magnitude. The discrepancy might be due to our generous estimates of Chicago's population, piano ownership rates, or tuning frequency.
-          </p>
-      </div>
-      
-      {/* Other Examples section */}
-      <div className="highlight-section p-4 rounded-xl mb-6">
-        <h3 className="font-medium mt-0 mb-3">Other Examples:</h3>
-        <ul className="list-disc pl-5 m-0 space-y-3 leading-normal">
-          <li>How many more years of life expectancy do women in Russia have compared to men?</li>
-          <li>For each person having died as a result of nuclear accidents in the past 50 years, how many have died as a result of air pollution from coal?</li>
-          <li>How many chickens are killed for meat every year (as of 2018)?</li>
-          <li>Launch cost per kilogram of payload into space?</li>
-        </ul>
-      </div>
-      
-      {/* Strategy Tips section */}
-      <div className="mb-6 leading-normal">
-        <h3 className="text-xl font-display font-medium pb-2.5 border-b mb-6">Strategy Tips</h3>
-        <p className="mb-3">
-          Getting better at Fermi Poker is closely linked to becoming better at rational thinking, world-modeling and understanding the cognitive biases that we have:
-        </p>
-        <ul className="list-disc pl-5 space-y-3">
-          <li>
-            <span className="font-bold">Bayesian updating:</span> Consider how the information you've gained from hints impacts the assumptions underlying your guess. And then fold or raise your bet accordingly, but don't do it all the time, because it will make it easy for people to predict you.
-          </li>
-          <li>
-            <span className="font-bold">World-modeling:</span> It will serve you well to memorize at least some numbers to build your sense of magnitude up. You need a baseline for the scale of various distances, populations, speeds, etc. before you can start making educated guesses about them. But unlike other trivia quiz games, rote memorization and obscure facts about celebrities aren't important in Fermi Poker.
-          </li>
-          <li>
-            <span className="font-bold">Opponent modeling:</span> As in standard poker, there is of course some importance in understand the ticks and general psychological profile of your opponent. But also here in Fermi Poker it's unique that you can observe in what categories your opponent(s) make good guesses, in which categories they are clueless, and then act accordingly. Of course, they might try to do some deception.
-          </li>
-        </ul>
-      </div>
-      
-      {/* Fixed Start Game Button */}
-      <div className="fixed-start-button">
-        <button 
-          onClick={goToCategories}
-          className="start-game-button"
+
+        <button
+          type="button"
+          className="home-action-button home-play-button"
+          onClick={() => navigate('/categories')}
         >
-          <span className="mr-2">See questions</span>
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" />
-          </svg>
+          Play
         </button>
-      </div>
-    </div>
+
+        <button
+          type="button"
+          className="home-action-button home-rules-button"
+          onClick={() => navigate('/rules')}
+        >
+          Rules / Description
+        </button>
+      </section>
+    </main>
   );
 };
 

--- a/src/components/FermiPokerRules.js
+++ b/src/components/FermiPokerRules.js
@@ -1,0 +1,206 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const FermiPokerIntro = () => {
+  const navigate = useNavigate();
+
+  const goToCategories = () => {
+    navigate('/categories');
+  };
+
+  // Example gameplay steps
+  const gameplaySteps = [
+    {
+      number: "1",
+      title: "Question reveal",
+      content: "Before seeing the question, each player must put one or more chips into the pot. Then the question is revealed, for example: \"How many chickens are killed every year for meat?\" The size of this mandatory bet should increase every other question."
+    },
+    {
+      number: "2",
+      title: "Secret guesses",
+      content: "Each player secretly writes down their guess as a range (e.g. 20 billion to 100 billion). Alternatively, you can also require everyone to play with exact numbers instead of ranges."
+    },
+    {
+      number: "3",
+      title: "Betting round #1",
+      content: "Betting moves clockwise, starting with a different player each question. On your turn, you may *check* (pass without betting, if no one has bet yet), *raise* (bet more than the current highest bet), *call* (match it), or *fold* (drop out and forfeit the pot). Betting continues until all players have either folded or matched the highest bet."
+    },
+    {
+      number: "4",
+      title: "Hint #1 (+ Betting round #2)",
+      content: "When the first betting round is over, the first hint is revealed. The hint helps all players to estimate how good the initial guess is. As in the first betting round, players can now perform various actions."
+    },
+    {
+      number: "5",
+      title: "Hint #2 (+ Betting round #3)",
+      content: "After the second betting round is over, a second hint is revealed and the third betting round is played."
+    },
+    {
+      number: "6",
+      title: "Answer reveal",
+      content: "Before the fourth and final betting round, the answer to the guessing question is revealed so that all players know if they are close to the answer."
+    },
+    {
+      number: "7",
+      title: "Betting round #4",
+      content: "After the answer reveal, there is a fourth and final betting round. After the answer reveal, there is a fourth and final betting round."
+    },
+    {
+      number: "8",
+      title: "Showdown",
+      content: "When the final betting round ends with two or more players still in, everyone left reveals their guess. Folded players—and anyone who won before it came to the showdown—don't have to reveal their guess. The pot goes to the player with the narrowest range that contains the correct answer; if several ranges are equally narrow, those players split the pot. If no player has the correct answer inside their range, whoever's median of their range is closest to the answer wins."
+    }
+  ];
+
+  return (
+    <div className="intro-section p-1 mb-20">
+      {/* What is Fermi Poker section */}
+      <div className="mb-6">
+        <h2 className="text-header-small sm:text-header font-display font-medium pb-2.5 border-b border-golden-accent mt-0 mb-3">What is Fermi Poker?</h2>
+        <p className="leading-normal">
+          Fermi Poker is like poker, but instead of cards, players make guesses about questions that seem unknowable at first — like "How many humans have ever lived?"
+        </p>
+        <p className="leading-normal">
+          Players write down secret guesses, bet on their answers, get helpful hints, bet again, and the closest guess wins.
+        </p>
+      </div>
+
+      {/* What Do You Need section */}
+      <div className="highlight-section p-4 rounded-xl mb-6">
+        <h3 className="font-medium mt-0 mb-3">What Do You Need?</h3>
+        <ul className="list-disc pl-5 m-0 space-y-3 leading-normal">
+          <li>At least one other person physically present to play with you, but it's more fun with larger groups</li>
+          <li>Something to write down guesses, and poker chips or other play money</li>
+        </ul>
+      </div>
+
+      {/* Example Gameplay section */}
+      <div className="mb-6">
+        <h3 className="text-xl font-display font-medium pb-2.5 border-b mb-6">How to Play</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-5">
+          {gameplaySteps.map((step, index) => (
+            <div key={index} className="gameplay-steps">
+              <div className="gameplay-step-row">
+                <div className="step-number-circle">{step.number}</div>
+                <div className="step-content">
+                  <h4>{step.title}</h4>
+                  <p className="leading-normal">{step.content}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Rules section */}
+      <div className="mb-6 leading-normal">
+        <h3 className="text-xl font-display font-medium pb-2.5 border-b mb-6">Rules</h3>
+        <p className="mb-3">
+          If you are familiar with No Limit Texas Hold'Em Poker, you'll find that the rules are very similar,
+          however we have made some adjustment to maximize the educational potential and to accommodate the fact that we don't have cards:
+        </p>
+        <ul className="list-disc pl-5 space-y-2">
+          <li>If you were the last to raise in a betting round, you can't raise again.</li>
+          <li>If everyone has folded, the remaining player doesn't have to show his answer.</li>
+          <li>A player can fold at any time, which means he gives up all the chips he has already put into the pot, including the mandatory ante, but he doesn't have to show his answer.</li>
+          <li>Each round, players have to pay a mandatory minimum ante. If one has less chips than the mandatory ante, one automatically goes all-in.</li>
+          <li>A player going all-in, can not win from another player more than he went all-in with. If other players continue playing with more chips, a side-pot is created that only the people can win that have contributed to it.</li>
+        </ul>
+      </div>
+
+      {/* Meta-Game Option section */}
+      <div className="highlight-section p-4 rounded-xl mb-6">
+        <h3 className="font-medium mt-0 mb-3">Meta-Game Option</h3>
+        <ul className="list-disc pl-5 m-0 space-y-3 leading-normal">
+          <li>When playing in large groups, which might have very different skill levels, it might make sense to add another layer to the game so that it is more fun for everyone even if you have folded and are just watching.</li>
+          <li>In games with meta-game enabled, players can predict who will win each question. With 3 correct predictions, bankrupt players can rejoin the game with a small stack.</li>
+          <li>Players can't bet on themselves</li>
+        </ul>
+      </div>
+
+      {/* Example Worked Through section */}
+      <div className="mb-6 leading-normal">
+          <h3 className="text-xl font-display font-medium pb-2.5 border-b mb-6">An Example Worked Far Too In-Depth</h3>
+          <p className="mb-3">
+            It's hard to explain how to solve a Fermi Question, so let me show you one and walk you through it. Here's a classic, hoping that the pandemic didn't change the answer.
+          </p>
+          <p className="mb-3 font-bold italic">How many piano tuners are there in Chicago?</p>
+          <p className="mb-3">
+            To begin, we need the population of Chicago. The population turns out to be around 2.5 million, but keeping Remark 2.2 in mind, the metropolitan area is a bit higher, about 10 million. We'll go in between at about 5 million.
+          </p>
+          <p className="mb-3">
+            We'll first consider how many pianos there are in Chicago, and by extension, the demand of piano tuners for those pianos. The average household size in the US is about 2; there are many people who are single, some live with a partner, and some (fewer) have children as well. Let's then say that about 1 in 10 households own a piano that needs to be tuned yearly. This gives us about:
+          </p>
+          <div className="p-4 bg-gray-50 dark:bg-dark-soft rounded-lg mb-3">
+            5,000,000 people ÷ 2 people per household × 0.1 pianos per household = 250,000 pianos
+          </div>
+          <p className="mb-3">
+            Let's also consider that some business establishments have pianos: schools, churches, concert venues, recording studios, and so on. These are fewer in number than households, but more likely to have pianos. Let's say there are about 10,000 such establishments with pianos in Chicago.
+          </p>
+          <div className="p-4 bg-gray-50 dark:bg-dark-soft rounded-lg mb-3">
+            250,000 + 10,000 = 260,000 pianos in Chicago
+          </div>
+          <p className="mb-3">
+            Now, if a piano needs to be tuned once per year on average, and a tuner can tune, say, 5 pianos per day, working 5 days a week for 50 weeks a year, each tuner can service:
+          </p>
+          <div className="p-4 bg-gray-50 dark:bg-dark-soft rounded-lg mb-3">
+            5 pianos/day × 5 days/week × 50 weeks/year = 1,250 pianos per year per tuner
+          </div>
+          <p className="mb-3">
+            So the number of piano tuners needed in Chicago would be:
+          </p>
+          <div className="p-4 bg-gray-50 dark:bg-dark-soft rounded-lg mb-3">
+            260,000 pianos ÷ 1,250 pianos per tuner = 208 piano tuners
+          </div>
+          <p>
+            Rounding a bit, we'd estimate there are about 200 piano tuners in Chicago. The actual number is around 40-50, which is in the same order of magnitude. The discrepancy might be due to our generous estimates of Chicago's population, piano ownership rates, or tuning frequency.
+          </p>
+      </div>
+
+      {/* Other Examples section */}
+      <div className="highlight-section p-4 rounded-xl mb-6">
+        <h3 className="font-medium mt-0 mb-3">Other Examples:</h3>
+        <ul className="list-disc pl-5 m-0 space-y-3 leading-normal">
+          <li>How many more years of life expectancy do women in Russia have compared to men?</li>
+          <li>For each person having died as a result of nuclear accidents in the past 50 years, how many have died as a result of air pollution from coal?</li>
+          <li>How many chickens are killed for meat every year (as of 2018)?</li>
+          <li>Launch cost per kilogram of payload into space?</li>
+        </ul>
+      </div>
+
+      {/* Strategy Tips section */}
+      <div className="mb-6 leading-normal">
+        <h3 className="text-xl font-display font-medium pb-2.5 border-b mb-6">Strategy Tips</h3>
+        <p className="mb-3">
+          Getting better at Fermi Poker is closely linked to becoming better at rational thinking, world-modeling and understanding the cognitive biases that we have:
+        </p>
+        <ul className="list-disc pl-5 space-y-3">
+          <li>
+            <span className="font-bold">Bayesian updating:</span> Consider how the information you've gained from hints impacts the assumptions underlying your guess. And then fold or raise your bet accordingly, but don't do it all the time, because it will make it easy for people to predict you.
+          </li>
+          <li>
+            <span className="font-bold">World-modeling:</span> It will serve you well to memorize at least some numbers to build your sense of magnitude up. You need a baseline for the scale of various distances, populations, speeds, etc. before you can start making educated guesses about them. But unlike other trivia quiz games, rote memorization and obscure facts about celebrities aren't important in Fermi Poker.
+          </li>
+          <li>
+            <span className="font-bold">Opponent modeling:</span> As in standard poker, there is of course some importance in understand the ticks and general psychological profile of your opponent. But also here in Fermi Poker it's unique that you can observe in what categories your opponent(s) make good guesses, in which categories they are clueless, and then act accordingly. Of course, they might try to do some deception.
+          </li>
+        </ul>
+      </div>
+
+      {/* Fixed Start Game Button */}
+      <div className="fixed-start-button">
+        <button
+          onClick={goToCategories}
+          className="start-game-button"
+        >
+          <span className="mr-2">See questions</span>
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FermiPokerIntro;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2168,3 +2168,236 @@ header.pt-28 {
 .dark .question-overlay-instructions .border-answer-border {
   border-color: var(--dark-border);
 }
+
+/* Dark Art-Deco Ray Theme */
+:root {
+  --midnight-void: #05051f;
+  --midnight-blue: #08082d;
+  --midnight-indigo: #12113f;
+  --ray-violet: rgba(132, 125, 221, 0.26);
+  --ray-violet-soft: rgba(132, 125, 221, 0.12);
+  --electric-cyan: #45c5e6;
+  --electric-cyan-soft: rgba(69, 197, 230, 0.4);
+  --hot-pink: #ef3b95;
+  --hot-pink-soft: rgba(239, 59, 149, 0.42);
+  --sun-gold: #ffb42e;
+  --paper-white: #fff9e8;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+  background: var(--midnight-void);
+}
+
+.geometric-background {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  background-color: var(--midnight-void);
+  background-image:
+    radial-gradient(circle at 50% 8%, rgba(105, 92, 224, 0.38) 0, rgba(105, 92, 224, 0) 24rem),
+    radial-gradient(circle at 13% 15%, rgba(69, 197, 230, 0.16) 0, rgba(69, 197, 230, 0) 10rem),
+    radial-gradient(circle at 86% 14%, rgba(239, 59, 149, 0.16) 0, rgba(239, 59, 149, 0) 11rem),
+    linear-gradient(180deg, #02031a 0%, #08082d 43%, #05051f 100%);
+}
+
+.geometric-background::before,
+.geometric-background::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+}
+
+.geometric-background::before {
+  z-index: 0;
+  background:
+    linear-gradient(80deg, transparent 0 7%, var(--ray-violet-soft) 7.5% 15%, transparent 15.5% 24%, rgba(122, 129, 224, 0.19) 24.5% 33%, transparent 33.5% 43%, rgba(35, 31, 92, 0.58) 43.5% 53%, transparent 53.5% 63%, rgba(122, 129, 224, 0.18) 63.5% 72%, transparent 72.5% 83%, var(--ray-violet-soft) 83.5% 92%, transparent 92.5% 100%),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.03) 0 1px, transparent 1px 7rem);
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  opacity: 0.86;
+  transform: scaleX(1.45);
+  transform-origin: top center;
+}
+
+.geometric-background::after {
+  z-index: 0;
+  opacity: 0.72;
+  background-image:
+    radial-gradient(circle, rgba(255, 245, 202, 0.85) 0 1.5px, transparent 2px),
+    radial-gradient(circle, rgba(255, 180, 46, 0.45) 0 1px, transparent 1.5px),
+    radial-gradient(circle, rgba(69, 197, 230, 0.22) 0 1px, transparent 1.75px),
+    radial-gradient(circle at 18% 14%, rgba(255, 255, 255, 0.17), transparent 7rem),
+    radial-gradient(circle at 78% 38%, rgba(255, 180, 46, 0.16), transparent 9rem);
+  background-position: 7% 11%, 34% 23%, 72% 19%, 0 0, 0 0;
+  background-size: 8.5rem 9.5rem, 11rem 12rem, 14rem 13rem, 100% 100%, 100% 100%;
+}
+
+.dark {
+  color: var(--paper-white);
+  background-color: transparent;
+}
+
+.dark h1,
+.dark h2,
+.dark h3,
+.dark h4,
+.dark h5,
+.dark h6 {
+  color: var(--paper-white);
+  text-shadow: 0 3px 0 rgba(0, 0, 0, 0.45), 0 0 28px rgba(69, 197, 230, 0.18);
+}
+
+.dark header a {
+  color: var(--paper-white);
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+  text-shadow: 0 5px 0 #02031a, 0 0 34px rgba(255, 180, 46, 0.22);
+}
+
+.dark .bg-golden-accent {
+  background: linear-gradient(90deg, transparent, var(--hot-pink), var(--electric-cyan), transparent);
+  box-shadow: 0 0 18px rgba(69, 197, 230, 0.52);
+}
+
+.dark .main-bg {
+  position: relative;
+  border: 1px solid rgba(69, 197, 230, 0.62);
+  background:
+    linear-gradient(180deg, rgba(15, 14, 55, 0.78), rgba(5, 5, 31, 0.82)),
+    radial-gradient(circle at 50% 0%, rgba(255, 180, 46, 0.09), transparent 19rem);
+  box-shadow:
+    inset 0 0 0 2px rgba(239, 59, 149, 0.23),
+    inset 0 0 42px rgba(69, 197, 230, 0.13),
+    0 24px 80px rgba(0, 0, 0, 0.46);
+  backdrop-filter: blur(5px);
+}
+
+.dark .main-bg::before {
+  content: "";
+  position: absolute;
+  inset: 0.75rem;
+  border: 2px solid rgba(69, 197, 230, 0.48);
+  border-left-color: rgba(239, 59, 149, 0.58);
+  border-bottom-color: rgba(239, 59, 149, 0.55);
+  border-radius: 0.7rem;
+  pointer-events: none;
+  z-index: 0;
+  box-shadow: 0 0 22px rgba(69, 197, 230, 0.18);
+}
+
+.dark .main-bg::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.35;
+  background-image:
+    radial-gradient(circle, rgba(0, 0, 0, 0.65) 0 1px, transparent 1.5px),
+    radial-gradient(circle, rgba(255, 245, 202, 0.5) 0 1px, transparent 1.75px);
+  background-size: 2.2rem 2.2rem, 7rem 6rem;
+}
+
+.main-bg > * {
+  position: relative;
+  z-index: 1;
+}
+
+.dark .highlight-section,
+.dark .gameplay-steps,
+.dark .category-info-banner,
+.dark .intro-dropdown,
+.dark .dropdown-content,
+.dark .dropdown-header,
+.dark .category-menu,
+.dark .settings-menu {
+  background-color: rgba(9, 9, 43, 0.78);
+  border-color: rgba(69, 197, 230, 0.34);
+  box-shadow: inset 0 0 0 1px rgba(239, 59, 149, 0.08), 0 12px 28px rgba(0, 0, 0, 0.2);
+}
+
+.dark .gameplay-steps,
+.dark .highlight-section {
+  border: 1px solid rgba(69, 197, 230, 0.24);
+}
+
+.dark .step-number-circle,
+.dark .hint-number,
+.dark .answer-letter,
+.dark .hint-number-small,
+.dark .answer-letter-small {
+  color: var(--paper-white);
+  border-color: var(--electric-cyan);
+  background: rgba(69, 197, 230, 0.12);
+  box-shadow: 0 0 18px rgba(69, 197, 230, 0.2);
+}
+
+.dark .start-game-button {
+  color: var(--paper-white);
+  border: 0;
+  background: linear-gradient(135deg, #f0449b 0%, #e8348b 55%, #c82379 100%);
+  border-bottom: 4px solid rgba(104, 6, 55, 0.86);
+  box-shadow: 0 18px 38px rgba(239, 59, 149, 0.34), inset 0 1px 0 rgba(255, 255, 255, 0.24);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.dark .start-game-button:hover {
+  transform: translateY(1px);
+  box-shadow: 0 12px 26px rgba(239, 59, 149, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.24);
+}
+
+.dark button:not(.start-game-button),
+.dark .settings-theme-toggle,
+.dark .settings-toggle {
+  color: var(--paper-white);
+  background: rgba(9, 9, 43, 0.86);
+  border-color: rgba(69, 197, 230, 0.38);
+}
+
+.dark button:not(.start-game-button):hover,
+.dark .settings-theme-toggle:hover,
+.dark .settings-toggle:hover,
+.dark .category-button:hover {
+  background: rgba(69, 197, 230, 0.16);
+  border-color: rgba(69, 197, 230, 0.66);
+}
+
+.dark .category-button.active,
+.dark .stepper-step.active .stepper-circle,
+.dark .stepper-step.completed .stepper-circle,
+.dark .stepper-line.completed {
+  background: linear-gradient(135deg, var(--electric-cyan), #2ebdd1);
+  border-color: var(--electric-cyan);
+  color: #04041f;
+}
+
+.dark .card-front,
+.dark .card-back,
+.dark .hint-front,
+.dark .hint-back,
+.dark .answer-front,
+.dark .answer-back,
+.dark .question-overlay-content {
+  background-color: rgba(9, 9, 43, 0.86);
+  border-color: rgba(69, 197, 230, 0.34);
+  color: var(--paper-white);
+}
+
+@media (max-width: 640px) {
+  .geometric-background::before {
+    transform: scaleX(2.1);
+  }
+
+  .dark .main-bg {
+    border-left-color: rgba(239, 59, 149, 0.5);
+    border-right-color: rgba(69, 197, 230, 0.58);
+  }
+
+  .dark header a {
+    font-size: 2.3rem;
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -28,7 +28,7 @@ html, body {
   --error-text: #B91C1C;
   --darklight-border: #D3CFC8;
   --graylight-border: #E0DFDB;
-  
+
   /* Dark mode colors */
   --dark-bg: #1F1A15;
   --dark-surface: #1f1a15;
@@ -74,7 +74,7 @@ html, body {
   background-color: var(--main-bg);
   border: 1px solid var(--graylight-border);
 }
- 
+
 .dark .main-bg {
   background-color: var(--dark-surface);
   border: 1px solid var(--dark-border);
@@ -476,7 +476,7 @@ header.pt-28 {
 
 .dark .question-overlay-instructions .border-hint-border {
   border-color: var(--dark-border);
-} 
+}
 
 /* New Gameplay Steps Card Styling - Override existing styles */
 .gameplay-step-row {
@@ -832,12 +832,12 @@ header.pt-28 {
   .card-container {
     height: 110px;
   }
-  
+
   .hint-number {
     width: 40px;
     height: 40px;
   }
-  
+
   .answer-letter {
     width: 40px;
     height: 40px;
@@ -1426,16 +1426,16 @@ header.pt-28 {
     padding-left: 1rem;
     padding-right: 1rem;
   }
-  
+
   .sm\:p-5 {
     padding: 1.25rem;
   }
-  
+
   .sm\:text-4xl {
     font-size: 2.25rem;
     line-height: 2.5rem;
   }
-  
+
   .sm\:text-2xl {
     font-size: 1.5rem;
     line-height: 2rem;
@@ -1446,13 +1446,13 @@ header.pt-28 {
     line-height: 2rem;
     padding-bottom: 0.75rem;
   }
-  
+
   .sm\:text-3xl {
     font-size: 1.875rem;
     line-height: 2.25rem;
     margin-top: 1rem;
   }
-  
+
   .sm\:gap-4 {
     gap: 1rem;
   }
@@ -1545,14 +1545,14 @@ header.pt-28 {
     align-items: flex-start;
     gap: 0;
   }
-  
+
   .category-buttons-wrapper {
     flex-direction: column-reverse;
     width: 100%;
     margin-top: 12px;
     gap: 6px;
   }
-  
+
   .category-buttons-wrapper button {
     width: 100%;
     margin-left: 0 !important;
@@ -1919,7 +1919,7 @@ header.pt-28 {
 
 .dark .question-overlay-skip-btn:hover {
   border-bottom-width: 1px;
-} 
+}
 
 .question-overlay-instructions ul {
   margin: 0 auto;
@@ -2118,23 +2118,23 @@ header.pt-28 {
     width: 1rem;
     height: 1rem;
   }
-  
+
   .stepper-label {
     font-size: 15px;
     min-width: 60px;
     position: absolute;
     margin-top: 30px;
   }
-  
+
   .stepper-track {
     min-width: 900px; /* Smaller minimum width for mobile */
   }
-  
+
   .stepper-line {
     margin: 0.55rem 0.35rem 0 0.35rem;
     min-width: 100px;
   }
-} 
+}
 
 /* Hint display styles within overlay */
 .question-overlay-instructions .bg-hint-back {
@@ -2399,5 +2399,344 @@ body,
 
   .dark header a {
     font-size: 2.3rem;
+  }
+}
+
+/* Reference-style landing screen */
+.landing-mode {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 50% 9%, rgba(81, 72, 170, 0.38) 0 7rem, transparent 19rem),
+    radial-gradient(circle at 13% 11%, rgba(255, 255, 255, 0.12), transparent 7rem),
+    linear-gradient(180deg, #03031b 0%, #08072c 50%, #02021a 100%);
+}
+
+.landing-mode::before {
+  background:
+    linear-gradient(80deg,
+      rgba(87, 83, 156, 0.32) 0 8%,
+      transparent 8.3% 24%,
+      rgba(109, 113, 190, 0.34) 24.3% 34%,
+      transparent 34.3% 45%,
+      rgba(5, 5, 28, 0.72) 45.3% 54%,
+      transparent 54.3% 65%,
+      rgba(109, 113, 190, 0.34) 65.3% 75%,
+      transparent 75.3% 91%,
+      rgba(87, 83, 156, 0.32) 91.3% 100%);
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+  transform: scaleX(1.6);
+  transform-origin: top center;
+  opacity: 1;
+}
+
+.landing-mode::after {
+  opacity: 0.86;
+  background-image:
+    radial-gradient(circle, rgba(255, 246, 210, 0.75) 0 1.75px, transparent 2.4px),
+    radial-gradient(circle, rgba(255, 183, 70, 0.4) 0 1.2px, transparent 1.8px),
+    radial-gradient(circle, rgba(0, 0, 18, 0.9) 0 1px, transparent 1.6px),
+    radial-gradient(circle at 14% 16%, rgba(255, 255, 255, 0.13), transparent 5rem),
+    radial-gradient(circle at 84% 38%, rgba(255, 180, 80, 0.11), transparent 6rem);
+  background-position: 8% 8%, 28% 19%, 12% 3%, 0 0, 0 0;
+  background-size: 7.4rem 8.2rem, 10.5rem 11.5rem, 2.7rem 2.7rem, 100% 100%, 100% 100%;
+}
+
+.landing-content {
+  max-width: 760px;
+  min-height: 100vh;
+  padding: 0 !important;
+}
+
+.landing-main {
+  min-height: 100vh;
+}
+
+.quiz-poker-home {
+  position: relative;
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8.8rem 1.7rem 4.2rem;
+  color: var(--paper-white);
+}
+
+.quiz-poker-frame {
+  position: absolute;
+  inset: 1.25rem 1.45rem 1.2rem;
+  border-top: 4px solid #5bcdf0;
+  border-right: 4px solid #5bcdf0;
+  border-bottom: 4px solid #f04aa2;
+  border-left: 4px solid #f04aa2;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.28),
+    0 0 18px rgba(91, 205, 240, 0.28),
+    0 0 18px rgba(240, 74, 162, 0.22);
+  pointer-events: none;
+}
+
+.quiz-poker-frame::before,
+.quiz-poker-frame::after {
+  content: "";
+  position: absolute;
+  left: 1.05rem;
+  right: 1.05rem;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.quiz-poker-frame::before {
+  top: 1rem;
+}
+
+.quiz-poker-frame::after {
+  bottom: 1rem;
+}
+
+.frame-corner {
+  position: absolute;
+  width: 2.15rem;
+  height: 2.15rem;
+  border: 4px solid currentColor;
+}
+
+.frame-corner-top-left {
+  top: auto;
+  left: -0.15rem;
+  bottom: -0.15rem;
+  color: #f04aa2;
+}
+
+.frame-corner-top-right {
+  right: -0.15rem;
+  bottom: -0.15rem;
+  color: #d7c2e8;
+}
+
+.frame-corner-bottom-left {
+  left: -0.15rem;
+  bottom: -0.15rem;
+  color: #f04aa2;
+}
+
+.frame-corner-bottom-right {
+  right: -0.15rem;
+  bottom: -0.15rem;
+  color: #d7c2e8;
+}
+
+.frame-knot {
+  position: absolute;
+  width: 1.05rem;
+  height: 1.05rem;
+  border: 4px solid currentColor;
+  transform: rotate(45deg);
+  background: #070629;
+}
+
+.frame-knot-top-left,
+.frame-knot-bottom-left {
+  color: #f04aa2;
+}
+
+.frame-knot-top-right,
+.frame-knot-bottom-right {
+  color: #5bcdf0;
+}
+
+.frame-knot-left-top,
+.frame-knot-left-bottom {
+  color: #e799d3;
+}
+
+.frame-knot-right-top,
+.frame-knot-right-bottom {
+  color: #74d5f2;
+}
+
+.frame-knot-top-left { top: -0.75rem; left: 29%; }
+.frame-knot-top-right { top: -0.75rem; right: 29%; }
+.frame-knot-left-top { left: -0.72rem; top: 17%; }
+.frame-knot-left-bottom { left: -0.72rem; bottom: 17%; }
+.frame-knot-right-top { right: -0.72rem; top: 17%; }
+.frame-knot-right-bottom { right: -0.72rem; bottom: 17%; }
+.frame-knot-bottom-left { bottom: -0.75rem; left: 30%; }
+.frame-knot-bottom-right { bottom: -0.75rem; right: 30%; }
+
+.home-flag {
+  position: absolute;
+  top: 1.25rem;
+  left: 1.9rem;
+  z-index: 4;
+  width: 7.45rem;
+  height: 5rem;
+  box-shadow: 0 14px 22px rgba(0, 0, 0, 0.3);
+}
+
+.home-flag span {
+  display: block;
+  height: 33.333%;
+}
+
+.flag-red { background: #bd1d2d; }
+.flag-white { background: #ffffff; }
+.flag-blue { background: #21468b; }
+
+.home-info-button {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.9rem;
+  z-index: 4;
+  display: flex;
+  width: 5.25rem;
+  height: 5.25rem;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 999px;
+  background: #ffb32f;
+  color: #ffffff;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 3.85rem;
+  font-weight: 700;
+  line-height: 1;
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.25);
+}
+
+.quiz-poker-hero {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding-top: 0.5rem;
+}
+
+.quiz-poker-title {
+  margin: 0;
+  color: #fff9e8;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(5.5rem, 18vw, 10.2rem);
+  font-weight: 900;
+  letter-spacing: -0.085em;
+  line-height: 0.77;
+  text-align: center;
+  text-transform: uppercase;
+  text-shadow:
+    0.09em 0.08em 0 #02021a,
+    0.12em 0.12em 0 rgba(0, 0, 0, 0.94),
+    0 0 0.26em rgba(255, 249, 232, 0.14);
+  transform: scaleX(0.9);
+}
+
+.quiz-poker-title span {
+  display: block;
+}
+
+.quiz-poker-title span:first-child {
+  margin-bottom: 0.1em;
+}
+
+.quiz-poker-actions {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  width: min(100%, 29.5rem);
+  flex-direction: column;
+  align-items: center;
+  gap: 1.55rem;
+}
+
+.question-count {
+  margin: 0 0 0.05rem;
+  color: #ffffff;
+  font-size: clamp(1.2rem, 4vw, 1.75rem);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  text-align: center;
+  text-shadow: 0 3px 10px rgba(0, 0, 0, 0.75);
+}
+
+.home-action-button {
+  width: 100%;
+  min-height: 8.95rem;
+  border: 0;
+  border-radius: 1.75rem;
+  color: #ffffff;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(2.2rem, 8vw, 3.65rem);
+  font-weight: 900;
+  letter-spacing: 0.11em;
+  line-height: 1;
+  text-transform: uppercase;
+  box-shadow: 0 18px 24px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.12);
+}
+
+.home-play-button {
+  background: #ee3d96;
+}
+
+.home-rules-button {
+  min-height: 7.45rem;
+  background: #43c4e1;
+  font-size: clamp(1.55rem, 5vw, 2.55rem);
+  letter-spacing: 0.18em;
+}
+
+.home-action-button:hover,
+.home-info-button:hover {
+  filter: brightness(1.06);
+  transform: translateY(-1px);
+}
+
+@media (min-width: 700px) {
+  .landing-content {
+    border-left: 5px solid #03031b;
+    border-right: 5px solid #03031b;
+  }
+}
+
+@media (max-width: 520px) {
+  .landing-mode::before {
+    transform: scaleX(2.25);
+  }
+
+  .quiz-poker-home {
+    padding: 7.7rem 1.45rem 3.45rem;
+  }
+
+  .quiz-poker-frame {
+    inset: 1rem 1.2rem;
+  }
+
+  .home-flag {
+    left: 1.55rem;
+    width: 6.15rem;
+    height: 4.15rem;
+  }
+
+  .home-info-button {
+    right: 1.55rem;
+    width: 4.4rem;
+    height: 4.4rem;
+    font-size: 3.2rem;
+  }
+
+  .quiz-poker-actions {
+    width: calc(100% - 1.5rem);
+    gap: 1.35rem;
+  }
+
+  .home-action-button {
+    min-height: 8rem;
+    border-radius: 1.45rem;
+  }
+
+  .home-rules-button {
+    min-height: 6.55rem;
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a much darker, art‑deco / neon‑accent look with radiating ray graphics and speckled overlays to match the supplied reference image.
- Make the dark presentation the default so the app immediately showcases the new visual system on load.
- Bring UI components (cards, buttons, menus, overlays, stepper) into a cohesive neon/cyan/pink palette that reads well on the dark background.

### Description
- Default the app to dark mode and update the theme-color toggle in `src/App.js` to use the new darker palette (`#05051f` / `#100d29`).
- Add a large “Dark Art‑Deco Ray Theme” CSS block in `src/styles.css` introducing CSS variables, layered ray backgrounds, speckle overlays, and neon accent styles for `.geometric-background`, `.main-bg`, buttons, cards, stepper, hints and other UI pieces.
- Update PWA / browser metadata in `public/index.html` and `public/manifest.json` so the `theme-color` and `background_color` match the new midnight background.
- Minor z‑index/clip tweaks so the new background rays and overlays render behind content while framed panels keep legible content.
- Files changed: `src/App.js`, `src/styles.css`, `public/index.html`, `public/manifest.json`.

### Testing
- Ran `npm run build` and the production build completed successfully (build artifacts created), though existing unrelated ESLint warnings remain in other components. 
- Verified there are no obvious diff errors with `git diff --check` and the modified files were staged for commit. 
- Attempted an automated screenshot with Playwright (`npx --yes playwright ...`) but the run failed due to a registry/403 error when fetching Playwright, so visual regression capture could not be completed here.
- A local static build was produced and can be served (build output is ready for deployment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8d6e84f08329ba8e317d96389c4c)